### PR TITLE
fix(groups): Check translationString is a string

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -295,7 +295,9 @@ class Tag {
                 translationString = translationString[translationKey]
             }
         }
-        if(!translationString) translationString = translations[translationKey] || translationKey
+        if(!translationString) {
+            translationString = (typeof translations[translationKey] === 'string' && translations[translationKey]) || translationKey
+        }
         return translationString
     }
 


### PR DESCRIPTION
Fixes a bug we're experiencing where:

* We're translating a string within a translation group - eg i18n('About')`Company`
* There is another translation group with the same name as the string being translated - eg i18n('Company')`Location`
* The first translation group has not been loaded into i18nConfig yet (we do this dynamically on demand) - so `translations` does not yet contain an `About` key.

In this case Line 298 appears to try and find a translation without a group (personally I would not desire this behaviour but I understand the use case), but because `translations[translationKey]` is coincidentally another translation group `_getTranslation` returns that group's object instead of a string, causing a crash later on.

This PR checks that `translations[translationKey]` is a string before returning it.